### PR TITLE
Add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+DuaCrypto is a static crypto community website built with Vite + Tailwind CSS. It features AI agent discovery infrastructure (`.well-known` endpoints, OpenAPI spec, MCP server card, markdown content negotiation) and x402 HTTP payment endpoints.
+
+### Running the dev server
+
+```bash
+npm run dev
+```
+
+Starts Vite on port 5173 with HMR. The `dev` script first runs `scripts/generate-agent-assets.mjs` to regenerate agent discovery assets, then launches Vite.
+
+### Build
+
+```bash
+npm run build
+```
+
+Produces `dist/` with all static assets. No separate backend or database.
+
+### Available tests
+
+- `npm run test:markdown` — Unit tests for markdown content negotiation logic (always passes)
+- `npm run test:markdown -- --integration http://localhost:5173` — Integration test (requires dev server running; note: uses `curl.exe` on Windows, will fail on Linux with ENOENT — this is a known limitation)
+- `npm run verify:headers -- http://localhost:5173` — Verifies Link headers for agent discovery are served correctly
+
+### Key caveats
+
+- There is **no ESLint or TypeScript** configured in this project — no lint command exists.
+- The `postinstall` script (`scripts/patch-wrangler-templates.mjs`) patches wrangler internals to work around Cloudflare Pages bundling issues. It runs automatically on `npm install`/`npm ci`.
+- The x402 API plugin (`vite-plugins/x402-api.js`) is **not loaded in vite.config.js** by default. The `/api/*` routes will return 404 unless the plugin is explicitly added to the Vite config.
+- Environment variables in `.env.example` are all **optional** for local development.
+- The `scripts/test-markdown-negotiation.mjs` integration test uses `curl.exe` (Windows) — on Linux, the unit test portion passes but integration test fails with `spawn curl.exe ENOENT`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What's included

- Project overview (Vite + Tailwind static site with AI agent discovery infrastructure)
- Dev server, build, and test commands
- Key caveats discovered during setup:
  - No ESLint/TypeScript configured
  - `postinstall` patches wrangler templates
  - x402 API plugin not loaded by default
  - Integration test uses `curl.exe` (Windows-only)
  - All `.env` variables are optional for local dev

## Evidence of working dev environment

[demo_site_navigation.mp4](https://cursor.com/agents/bc-6bc85cd0-9ccc-434d-b327-e274ef143b96/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_site_navigation.mp4)

Site navigation demo showing Homepage → Services → About → Agent Skills JSON endpoint.

[Homepage hero section](https://cursor.com/agents/bc-6bc85cd0-9ccc-434d-b327-e274ef143b96/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[About page](https://cursor.com/agents/bc-6bc85cd0-9ccc-434d-b327-e274ef143b96/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fabout_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bc85cd0-9ccc-434d-b327-e274ef143b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bc85cd0-9ccc-434d-b327-e274ef143b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

